### PR TITLE
make flatten_filing ignore F6: 48-hour contribution reports

### DIFF
--- a/pyfec/filing.py
+++ b/pyfec/filing.py
@@ -270,7 +270,7 @@ class Filing(object):
         elif form_type in ['F13', 'F13A', 'F13N']:
             parsed_data = process_f13_header(summary)
 
-        elif form_type in ['F24', 'F99', 'F3L']:
+        elif form_type in ['F24', 'F24A', 'F24N', 'F6', 'F6A', 'F6N', 'F99', 'F3L']:
             parsed_data = defaultdict(lambda:0)
                     
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 colorama==0.3.3
 humanize==0.5.1
-lxml==3.4.4
-psycopg2==2.6.1
 python-dateutil==2.4.2
 requests==2.7.0
 six==1.9.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     package_data={'pyfec': ['fec-csv-sources/*.csv']},
     license="Apache License 2.0",
     keywords='FEC election finance campaign data parsing scraping donation expenditure candidate committee',
-    install_requires=['lxml==3.4.4','psycopg2==2.6.1','python-dateutil==2.4.2','requests==2.7.0','six==1.9.0','wheel==0.24.0','colorama==0.3.3','humanize==0.5.1'],
+    install_requires=['python-dateutil==2.4.2','requests==2.7.0','six==1.9.0','wheel==0.24.0','colorama==0.3.3','humanize==0.5.1'],
     classifiers=['Development Status :: 3 - Alpha',
                  'Intended Audience :: Developers',
                  'Programming Language :: Python',


### PR DESCRIPTION
F6's are 48-hour notice of contributions, and only apply to candidate committees taking contributions of $1,000 or more in the final 20 days before an election. As submitted, they contain no summary info--if you wanna know the total contributed, you just gotta total up the contributions. See the original [form](http://www.fec.gov/pdf/forms/fecfrm6.pdf). 
